### PR TITLE
Update DebugMenu UI

### DIFF
--- a/libraries/debug-menu/build.gradle
+++ b/libraries/debug-menu/build.gradle
@@ -38,7 +38,7 @@ android {
 
 ext {
     PUBLISH_GROUP_ID = 'com.trendyol.android.devtools'
-    PUBLISH_VERSION = '0.3.0'
+    PUBLISH_VERSION = '0.3.1'
     PUBLISH_ARTIFACT_ID = 'debug-menu'
     PUBLISH_DESCRIPTION = "Android QA Debug Menu"
     PUBLISH_URL = "https://github.com/Trendyol/android-dev-tools"

--- a/libraries/debug-menu/src/main/res/layout/debug_menu_item.xml
+++ b/libraries/debug-menu/src/main/res/layout/debug_menu_item.xml
@@ -20,6 +20,7 @@
             android:layout_height="36dp"
             app:cardCornerRadius="12dp"
             app:contentPadding="6dp"
+            app:cardElevation="0dp"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toStartOf="@id/debugMenuTextTitle"
             app:layout_constraintHorizontal_chainStyle="spread_inside"

--- a/libraries/debug-menu/src/main/res/values/themes.xml
+++ b/libraries/debug-menu/src/main/res/values/themes.xml
@@ -1,6 +1,6 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
 
-    <style name="Theme.Devtools" parent="Theme.MaterialComponents.DayNight.NoActionBar">
+    <style name="Theme.Devtools" parent="Theme.MaterialComponents.DayNight.NoActionBar.Bridge">
         <item name="colorPrimary">@color/colorPrimary</item>
         <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
         <item name="android:windowLightStatusBar" tools:targetApi="m">?attr/isLightTheme</item>
@@ -16,5 +16,4 @@
         <item name="colorPrimary">@color/colorAccent</item>
         <item name="colorOnPrimary">@color/colorPrimary</item>
     </style>
-
 </resources>


### PR DESCRIPTION
- Extend DebugMenuActivity's theme from "Theme.MaterialComponents.DayNight.NoActionBar.Bridge".
- Set elevation to "0dp" for debug menu item icon frame view.
- Update `debug-menu` to `0.3.1`.