### PR TITLE
Add Dark Mode Support to DebugMenu

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
     ext.rx_version = "3.1.6"
     ext.rx_android_version = "3.0.2"
     ext.activity_version = "1.7.2"
-    ext.fragment_version = "1.5.7"
+    ext.fragment_version = "1.6.0"
     ext.preference_version = "1.2.0"
     ext.recycler_view_version = "1.3.0"
     ext.constraint_layout_version = "2.1.4"

--- a/libraries/debug-menu/build.gradle
+++ b/libraries/debug-menu/build.gradle
@@ -38,7 +38,7 @@ android {
 
 ext {
     PUBLISH_GROUP_ID = 'com.trendyol.android.devtools'
-    PUBLISH_VERSION = '0.3.1'
+    PUBLISH_VERSION = '0.4.0'
     PUBLISH_ARTIFACT_ID = 'debug-menu'
     PUBLISH_DESCRIPTION = "Android QA Debug Menu"
     PUBLISH_URL = "https://github.com/Trendyol/android-dev-tools"

--- a/libraries/debug-menu/src/main/res/layout/debug_menu_activity.xml
+++ b/libraries/debug-menu/src/main/res/layout/debug_menu_activity.xml
@@ -1,11 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
     <androidx.fragment.app.FragmentContainerView
         android:id="@+id/fragmentContainerViewMain"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"/>
+        android:layout_height="match_parent" />
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/libraries/debug-menu/src/main/res/layout/debug_menu_item.xml
+++ b/libraries/debug-menu/src/main/res/layout/debug_menu_item.xml
@@ -4,7 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    app:cardBackgroundColor="@color/colorPrimary"
+    app:cardBackgroundColor="@color/debug_menu_color_background_card"
     app:cardCornerRadius="16dp"
     app:cardElevation="0dp"
     app:cardUseCompatPadding="true"
@@ -32,7 +32,7 @@
                 android:id="@+id/debugMenuImageIcon"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
-                app:tint="@color/colorPrimary"
+                app:tint="@color/debug_menu_color_icon_tint"
                 tools:src="@android:drawable/ic_dialog_alert" />
         </androidx.cardview.widget.CardView>
 
@@ -75,7 +75,7 @@
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toEndOf="@id/debugMenuTextTitle"
             app:layout_constraintTop_toTopOf="parent"
-            app:thumbTint="@color/colorPrimary"
+            app:thumbTint="@color/debug_menu_color_switch_thumb_tint"
             app:track="@drawable/debug_menu_track_switch"
             app:trackTint="@color/dev_tools_color_switch_track"
             tools:checked="true" />

--- a/libraries/debug-menu/src/main/res/values-night/colors.xml
+++ b/libraries/debug-menu/src/main/res/values-night/colors.xml
@@ -1,6 +1,32 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <color name="colorPrimary">#000000</color>
-    <color name="colorPrimaryDark">#000000</color>
+    <color name="colorPrimary">#ffffff</color>
+    <color name="colorPrimaryDark">#ffffff</color>
     <color name="colorAccent">#1B72C0</color>
+
+    <color name="debug_menu_color_background_page">#010101</color>
+    <color name="debug_menu_color_title">#ffffff</color>
+    <color name="debug_menu_color_description">#999999</color>
+    <color name="debug_menu_color_background_switch">#1B72C0</color>
+    <color name="debug_menu_color_background_card">#171717</color>
+    <color name="debug_menu_color_icon_tint">#ffffff</color>
+    <color name="debug_menu_color_switch_thumb_tint">#ffffff</color>
+
+    <color name="debug_menu_color_item_0">#5BA6FF</color>
+    <color name="debug_menu_color_item_1">#A2DC23</color>
+    <color name="debug_menu_color_item_2">#53D2D1</color>
+    <color name="debug_menu_color_item_3">#9A91FE</color>
+    <color name="debug_menu_color_item_4">#FC9181</color>
+    <color name="debug_menu_color_item_5">#5C79E1</color>
+    <color name="debug_menu_color_item_6">#CA84E4</color>
+
+    <array name="debug_menu_array_item_color">
+        <item>@color/debug_menu_color_item_0</item>
+        <item>@color/debug_menu_color_item_1</item>
+        <item>@color/debug_menu_color_item_2</item>
+        <item>@color/debug_menu_color_item_3</item>
+        <item>@color/debug_menu_color_item_4</item>
+        <item>@color/debug_menu_color_item_5</item>
+        <item>@color/debug_menu_color_item_6</item>
+    </array>
 </resources>

--- a/libraries/debug-menu/src/main/res/values-night/themes.xml
+++ b/libraries/debug-menu/src/main/res/values-night/themes.xml
@@ -1,0 +1,19 @@
+<resources xmlns:tools="http://schemas.android.com/tools">
+
+    <style name="Theme.Devtools" parent="Theme.MaterialComponents.DayNight.NoActionBar.Bridge">
+        <item name="colorPrimary">@color/colorPrimary</item>
+        <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
+        <item name="android:windowLightStatusBar" tools:targetApi="m">?attr/isLightTheme</item>
+
+        <item name="materialButtonStyle">@style/Widget.App.Button</item>
+    </style>
+
+    <style name="Widget.App.Button" parent="Widget.MaterialComponents.Button">
+        <item name="materialThemeOverlay">@style/ThemeOverlay.App.Button</item>
+    </style>
+
+    <style name="ThemeOverlay.App.Button" parent="">
+        <item name="colorPrimary">@color/colorAccent</item>
+        <item name="colorOnPrimary">@color/colorPrimary</item>
+    </style>
+</resources>

--- a/libraries/debug-menu/src/main/res/values/colors.xml
+++ b/libraries/debug-menu/src/main/res/values/colors.xml
@@ -1,13 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <color name="colorPrimary">#ffffff</color>
-    <color name="colorPrimaryDark">#ffffff</color>
+    <color name="colorPrimaryDark">#000000</color>
     <color name="colorAccent">#1B72C0</color>
 
     <color name="debug_menu_color_background_page">#F3F4F9</color>
     <color name="debug_menu_color_title">#333333</color>
-    <color name="debug_menu_color_description">#666666</color>
+    <color name="debug_menu_color_description">#999999</color>
     <color name="debug_menu_color_background_switch">#1B72C0</color>
+    <color name="debug_menu_color_background_card">#ffffff</color>
+    <color name="debug_menu_color_icon_tint">#ffffff</color>
+    <color name="debug_menu_color_switch_thumb_tint">#ffffff</color>
 
     <color name="debug_menu_color_item_0">#5BA6FF</color>
     <color name="debug_menu_color_item_1">#A2DC23</color>

--- a/sample/src/main/java/com/trendyol/android/devtools/App.kt
+++ b/sample/src/main/java/com/trendyol/android/devtools/App.kt
@@ -22,9 +22,13 @@ class App : Application() {
 
         // Debug Menu
         DebugMenu.init(this)
-        val debugMenuItems = listOf(DummyClickDebugActionItem(baseContext), DummySwitchDebugActionItem())
+        val debugMenuItems = listOf(
+            AnalyticsLoggerDebugActionItem(),
+            DummyClickDebugActionItem(baseContext),
+            DummySwitchDebugActionItem(true),
+        )
         DebugMenu.addDebugActionItems(debugMenuItems)
-        DebugMenu.addDebugAction(AnalyticsLoggerDebugActionItem())
+        DebugMenu.addDebugAction(DummySwitchDebugActionItem())
 
         // Autofill Service
         AutofillService.Builder(this)

--- a/sample/src/main/java/com/trendyol/android/devtools/debugactionitem/AnalyticsLoggerDebugActionItem.kt
+++ b/sample/src/main/java/com/trendyol/android/devtools/debugactionitem/AnalyticsLoggerDebugActionItem.kt
@@ -8,6 +8,7 @@ class AnalyticsLoggerDebugActionItem : DebugActionItem.Switchable(
     text = "Analytics Logger",
     iconDrawableRes = R.drawable.ic_analytics,
     description = "Switch to hide notifications.",
+    initialState = true,
 ) {
 
     override fun onClickItem() {

--- a/sample/src/main/java/com/trendyol/android/devtools/debugactionitem/DummySwitchDebugActionItem.kt
+++ b/sample/src/main/java/com/trendyol/android/devtools/debugactionitem/DummySwitchDebugActionItem.kt
@@ -2,10 +2,11 @@ package com.trendyol.android.devtools.debugactionitem
 
 import com.trendyol.android.devtools.debugmenu.DebugActionItem
 
-class DummySwitchDebugActionItem : DebugActionItem.Switchable(
-    text = "Not yet clicked",
+class DummySwitchDebugActionItem(initialState: Boolean = false) : DebugActionItem.Switchable(
+    text = "Switchable",
     iconDrawableRes = android.R.drawable.ic_lock_lock,
     description = "Not yet switched!",
+    initialState = initialState
 ) {
 
     private var clickCounter = 1


### PR DESCRIPTION
- Add dark mode configuration of DebugMenu components.
- Update fragment ktx to 1.6.0.
- Update `debug-menu` to `0.4.0`.

Light:
![1](https://github.com/Trendyol/android-dev-tools/assets/11295209/e169bbc7-517e-4b2c-bc7e-c81c034da47c)

Dark:
![2](https://github.com/Trendyol/android-dev-tools/assets/11295209/4b10ea5c-327b-4c09-a8af-cc044b4928c8)