### PR TITLE
Feature/debug menu separate task

### DIFF
--- a/libraries/debug-menu/build.gradle
+++ b/libraries/debug-menu/build.gradle
@@ -38,7 +38,7 @@ android {
 
 ext {
     PUBLISH_GROUP_ID = 'com.trendyol.android.devtools'
-    PUBLISH_VERSION = '0.4.1'
+    PUBLISH_VERSION = '0.5.0'
     PUBLISH_ARTIFACT_ID = 'debug-menu'
     PUBLISH_DESCRIPTION = "Android QA Debug Menu"
     PUBLISH_URL = "https://github.com/Trendyol/android-dev-tools"

--- a/libraries/debug-menu/src/main/AndroidManifest.xml
+++ b/libraries/debug-menu/src/main/AndroidManifest.xml
@@ -8,7 +8,7 @@
         <activity
             android:name=".internal.ui.DebugMenuActivity"
             android:launchMode="singleInstance"
-            android:label="@string/dev_tools_notification_title"
+            android:label="@string/label"
             android:taskAffinity="com.trendyol.android.devtools.debugmenu.task"
             android:theme="@style/Theme.Devtools" />
     </application>

--- a/libraries/debug-menu/src/main/AndroidManifest.xml
+++ b/libraries/debug-menu/src/main/AndroidManifest.xml
@@ -8,6 +8,8 @@
         <activity
             android:name=".internal.ui.DebugMenuActivity"
             android:launchMode="singleInstance"
+            android:label="@string/dev_tools_notification_title"
+            android:taskAffinity="com.trendyol.android.devtools.debugmenu.task"
             android:theme="@style/Theme.Devtools" />
     </application>
 </manifest>

--- a/libraries/debug-menu/src/main/java/com/trendyol/android/devtools/debugmenu/DebugMenu.kt
+++ b/libraries/debug-menu/src/main/java/com/trendyol/android/devtools/debugmenu/DebugMenu.kt
@@ -1,6 +1,7 @@
 package com.trendyol.android.devtools.debugmenu
 
 import android.content.Context
+import android.content.Intent
 import com.trendyol.android.devtools.debugmenu.internal.di.ContextContainer
 import com.trendyol.android.devtools.debugmenu.internal.domain.DebugMenuUseCase
 import com.trendyol.android.devtools.debugmenu.internal.ui.DebugMenuActivity
@@ -25,9 +26,18 @@ object DebugMenu {
      * @param title to show above menu. Default is "Debug Menu".
      */
     fun show(title: String = "Debug Menu") {
-        val context = ContextContainer.getContext()
-        context.startActivity(DebugMenuActivity.newIntent(context, title))
+        ContextContainer.getContext().startActivity(newIntent(title))
     }
+
+    /**
+     * Creates an Intent to launch Debug menu.
+     *
+     * @param title to show above menu. Default is "Debug Menu".
+     *
+     * @return intent for Debug Menu's activity.
+     */
+    fun newIntent(title: String = "Debug Menu"): Intent =
+        DebugMenuActivity.newIntent(ContextContainer.getContext(), title)
 
     fun addDebugAction(debugAction: DebugActionItem) {
         addDebugActionItems(listOf(debugAction))

--- a/libraries/debug-menu/src/main/res/values/strings.xml
+++ b/libraries/debug-menu/src/main/res/values/strings.xml
@@ -1,4 +1,5 @@
 <resources>
+    <string name="label">Debug Menu</string>
     <string name="dev_tools_notification_title">Dev Tools</string>
     <string name="dev_tools_notification_description">Tap to open Dev Tools</string>
     <string name="dev_tools_notification_name">Android Dev Tools</string>


### PR DESCRIPTION
Updated Debug Menu component to make it separate task.

- Add `taskAffinity` flag to `AndroidManifest` description of `DebugMenuActivity` to launch it as separate task.
- Add new `newIntent` function to `DebugMenu` to provide `Intent` of `DebugMenuActivity`.
- [Change task label to "Debug Menu".
- Update `debug-menu` to `0.5.0`.

Whenever Debug Menu is opened, it will be listed as separate task on [Recents screen](https://developer.android.com/guide/components/activities/recents).

![ss](https://github.com/Trendyol/android-dev-tools/assets/11295209/0dbcffde-6924-4088-ad77-76ea603880fe)
