### PR TITLE
Analytics logger copy with transform

### DIFF
--- a/libraries/analytics-logger-no-op/build.gradle.kts
+++ b/libraries/analytics-logger-no-op/build.gradle.kts
@@ -36,7 +36,7 @@ android {
 
 extra.apply {
     set("PUBLISH_GROUP_ID", "com.trendyol.android.devtools")
-    set("PUBLISH_VERSION", "0.4.0")
+    set("PUBLISH_VERSION", "0.5.0")
     set("PUBLISH_ARTIFACT_ID", "analytics-logger-no-op")
     set("PUBLISH_DESCRIPTION", "Android Analytics Event Logger No-Op")
     set("PUBLISH_URL", "https://github.com/Trendyol/android-dev-tools")

--- a/libraries/analytics-logger-no-op/src/main/java/com/trendyol/android/devtools/analyticslogger/AnalyticsLogger.kt
+++ b/libraries/analytics-logger-no-op/src/main/java/com/trendyol/android/devtools/analyticslogger/AnalyticsLogger.kt
@@ -33,4 +33,12 @@ object AnalyticsLogger {
     ) {
         // no-op
     }
+
+    fun setEventTransformFunction(jsFunction: String) {
+        // no-op
+    }
+
+    fun getEventTransformFunction(): String {
+        return ""
+    }
 }

--- a/libraries/analytics-logger/build.gradle.kts
+++ b/libraries/analytics-logger/build.gradle.kts
@@ -41,7 +41,7 @@ android {
 
 extra.apply {
     set("PUBLISH_GROUP_ID", "com.trendyol.android.devtools")
-    set("PUBLISH_VERSION", "0.2.0")
+    set("PUBLISH_VERSION", "0.5.0")
     set("PUBLISH_ARTIFACT_ID", "analytics-logger")
     set("PUBLISH_DESCRIPTION", "Android Analytics Logger")
     set("PUBLISH_URL", "https://github.com/Trendyol/android-dev-tools")

--- a/libraries/analytics-logger/src/main/AndroidManifest.xml
+++ b/libraries/analytics-logger/src/main/AndroidManifest.xml
@@ -8,6 +8,7 @@
         <activity
             android:name=".internal.ui.MainActivity"
             android:launchMode="singleInstance"
+            android:taskAffinity="com.trendyol.android.devtools.analyticslogger.task"
             android:theme="@style/Theme.AnalyticsReporter" />
 
     </application>

--- a/libraries/analytics-logger/src/main/java/com/trendyol/android/devtools/analyticslogger/AnalyticsLogger.kt
+++ b/libraries/analytics-logger/src/main/java/com/trendyol/android/devtools/analyticslogger/AnalyticsLogger.kt
@@ -2,6 +2,7 @@ package com.trendyol.android.devtools.analyticslogger
 
 import android.app.Application
 import android.util.Log
+import androidx.core.content.edit
 import com.trendyol.android.devtools.analyticslogger.internal.NotificationManager
 import com.trendyol.android.devtools.analyticslogger.internal.di.ContextContainer
 
@@ -14,6 +15,37 @@ object AnalyticsLogger {
     fun init(application: Application, showNotification: Boolean = true) {
         ContextContainer.initialize(application)
         instance = NotificationManager(showNotification)
+    }
+
+    /**
+     * Sets a JavaScript function to transform event data.
+     * The function should be named 'transform' and take a single string parameter.
+     *
+     * Example:
+     * ```
+     * AnalyticsLogger.setEventTransformFunction("""
+     *     function transform(data) {
+     *         var parsed = JSON.parse(data);
+     *         return 'TRANSFORMED: ' + parsed.eventKey;
+     *     }
+     * """)
+     * ```
+     */
+    fun setEventTransformFunction(jsFunction: String) {
+        ContextContainer
+            .analyticsContainer
+            .sharedPreferencesManager
+            .edit {
+                putString("jsTransformFunction", jsFunction)
+            }
+    }
+
+    fun getEventTransformFunction(): String {
+        return ContextContainer
+            .analyticsContainer
+            .sharedPreferencesManager
+            .getString("jsTransformFunction", "")
+            .orEmpty()
     }
 
     fun show() {

--- a/libraries/analytics-logger/src/main/java/com/trendyol/android/devtools/analyticslogger/internal/NotificationManager.kt
+++ b/libraries/analytics-logger/src/main/java/com/trendyol/android/devtools/analyticslogger/internal/NotificationManager.kt
@@ -26,9 +26,8 @@ internal class NotificationManager constructor(private var showNotification: Boo
     private val scope = CoroutineScope(superVisorJob + Dispatchers.IO)
     private val analyticsContainer: AnalyticsContainer by lazy { ContextContainer.analyticsContainer }
     private val intent by lazy {
-        Intent(ContextContainer.getContext(), MainActivity::class.java).apply {
-            flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
-        }
+        Intent(ContextContainer.getContext(), MainActivity::class.java)
+            .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
     }
     private var lastEvent: Pair<String?, String?>? = null
 

--- a/libraries/analytics-logger/src/main/java/com/trendyol/android/devtools/analyticslogger/internal/di/AnalyticsContainer.kt
+++ b/libraries/analytics-logger/src/main/java/com/trendyol/android/devtools/analyticslogger/internal/di/AnalyticsContainer.kt
@@ -25,5 +25,4 @@ internal class AnalyticsContainer(private val context: Context) {
     val sharedPreferencesManager: SharedPreferences by lazy {
         context.getSharedPreferences("analytics_logger", Context.MODE_PRIVATE)
     }
-
 }

--- a/libraries/analytics-logger/src/main/java/com/trendyol/android/devtools/analyticslogger/internal/di/AnalyticsContainer.kt
+++ b/libraries/analytics-logger/src/main/java/com/trendyol/android/devtools/analyticslogger/internal/di/AnalyticsContainer.kt
@@ -1,6 +1,7 @@
 package com.trendyol.android.devtools.analyticslogger.internal.di
 
 import android.content.Context
+import android.content.SharedPreferences
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import com.trendyol.android.devtools.analyticslogger.internal.data.database.EventDatabase
@@ -20,4 +21,9 @@ internal class AnalyticsContainer(private val context: Context) {
     private val eventRepository: EventRepository by lazy { EventRepositoryImpl(eventDatabase) }
 
     val eventManager: EventManager by lazy { EventManagerImpl(eventRepository, moshi) }
+
+    val sharedPreferencesManager: SharedPreferences by lazy {
+        context.getSharedPreferences("analytics_logger", Context.MODE_PRIVATE)
+    }
+
 }

--- a/libraries/analytics-logger/src/main/java/com/trendyol/android/devtools/analyticslogger/internal/ui/detail/DetailFragment.kt
+++ b/libraries/analytics-logger/src/main/java/com/trendyol/android/devtools/analyticslogger/internal/ui/detail/DetailFragment.kt
@@ -14,14 +14,17 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.Toast
 import androidx.core.content.ContextCompat
+import androidx.core.widget.doAfterTextChanged
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.lifecycleScope
+import com.trendyol.android.devtools.analyticslogger.AnalyticsLogger
 import com.trendyol.android.devtools.analyticslogger.R
 import com.trendyol.android.devtools.analyticslogger.databinding.AnalyticsLoggerFragmentDetailBinding
 import com.trendyol.android.devtools.analyticslogger.internal.di.ContextContainer
 import com.trendyol.android.devtools.analyticslogger.internal.factory.ColorFactory
 import com.trendyol.android.devtools.analyticslogger.internal.ui.MainViewModel
+import com.trendyol.android.devtools.analyticslogger.internal.util.executeJS
 import kotlinx.coroutines.launch
 
 internal class DetailFragment : Fragment() {
@@ -46,7 +49,19 @@ internal class DetailFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        initializeViews()
         observeData()
+    }
+
+    private fun initializeViews() = with(binding) {
+        webViewJsExecutor.settings.javaScriptEnabled = true
+        editTextjsTransformFunction.setText(AnalyticsLogger.getEventTransformFunction())
+        editTextjsTransformFunction.doAfterTextChanged {
+            AnalyticsLogger.setEventTransformFunction(it.toString())
+        }
+        checkboxShowJSTransformFunction.setOnCheckedChangeListener { _, isChecked ->
+            editTextjsTransformFunction.visibility = if (isChecked) View.VISIBLE else View.GONE
+        }
     }
 
     private fun observeData() {
@@ -95,9 +110,35 @@ internal class DetailFragment : Fragment() {
         Toast.makeText(context, R.string.analytics_logger_toast_copied, Toast.LENGTH_SHORT).show()
     }
 
+    private fun copyTransformedToClipboard() {
+        val originalData = (viewModel.detailState.value as? DetailState.Selected)?.event?.json.orEmpty()
+
+        viewLifecycleOwner.lifecycleScope.launch {
+            try {
+                val transformedData = transformEventData(originalData)
+                val clipboard = context?.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+                clipboard.setPrimaryClip(ClipData.newPlainText(CLIPBOARD_TRANSFORMED_LABEL, transformedData))
+                Toast.makeText(context, R.string.analytics_logger_toast_copied, Toast.LENGTH_SHORT).show()
+            } catch (e: Exception) {
+                Toast.makeText(context, "Transform failed: ${e.message}", Toast.LENGTH_SHORT).show()
+            }
+        }
+    }
+
+    private suspend fun transformEventData(eventData: String): String {
+        val jsFunction = AnalyticsLogger.getEventTransformFunction()
+        val jsScript = with(StringBuilder()) {
+            append(jsFunction)
+            appendLine()
+            append("transform($eventData)")
+        }
+        return binding.webViewJsExecutor.executeJS(jsScript.toString())
+    }
+
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         when (item.itemId) {
             R.id.action_copy -> copyToClipboard()
+            R.id.action_test_assert -> copyTransformedToClipboard()
         }
         return super.onOptionsItemSelected(item)
     }
@@ -115,6 +156,7 @@ internal class DetailFragment : Fragment() {
     companion object {
         const val NAME = "detailFragment"
         private const val CLIPBOARD_LABEL = "Event Detail"
+        private const val CLIPBOARD_TRANSFORMED_LABEL = "Transformed Event Detail"
 
         fun newInstance(): DetailFragment {
             return DetailFragment()

--- a/libraries/analytics-logger/src/main/java/com/trendyol/android/devtools/analyticslogger/internal/util/WebViewUtil.kt
+++ b/libraries/analytics-logger/src/main/java/com/trendyol/android/devtools/analyticslogger/internal/util/WebViewUtil.kt
@@ -1,0 +1,32 @@
+package com.trendyol.android.devtools.analyticslogger.internal.util
+
+import android.util.Log
+import android.webkit.WebView
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+
+internal suspend fun WebView.executeJS(jsScript: String): String {
+    val tag = "WebViewJSExecution"
+    return suspendCancellableCoroutine { continuation ->
+        try {
+            evaluateJavascript(jsScript) { result ->
+                val cleanResult = if (result != null && result.startsWith('"') && result.endsWith('"')) {
+                    result.substring(1, result.length - 1)
+                        .replace("\\n", "\n")
+                        .replace("\\\"", "\"")
+                        .replace("\\\\", "\\")
+                } else {
+                    result ?: "TRANSFORM_ERROR: No result"
+                }
+                continuation.resume(cleanResult)
+            }
+            continuation.invokeOnCancellation {
+                destroy()
+            }
+        } catch (e: Exception) {
+            Log.e(tag, "Error executing JavaScript transform", e)
+            continuation.resumeWithException(e)
+        }
+    }
+}

--- a/libraries/analytics-logger/src/main/res/drawable/analytics_logger_check_list.xml
+++ b/libraries/analytics-logger/src/main/res/drawable/analytics_logger_check_list.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+  <path
+      android:pathData="M222,760 L80,618l56,-56 85,85 170,-170 56,57 -225,226ZM222,440L80,298l56,-56 85,85 170,-170 56,57 -225,226ZM520,680v-80h360v80L520,680ZM520,360v-80h360v80L520,360Z"
+      android:fillColor="#1f1f1f"/>
+</vector>

--- a/libraries/analytics-logger/src/main/res/layout/analytics_logger_fragment_detail.xml
+++ b/libraries/analytics-logger/src/main/res/layout/analytics_logger_fragment_detail.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.core.widget.NestedScrollView xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
     android:orientation="vertical">
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
+        android:layout_height="match_parent"
         android:orientation="vertical"
         android:padding="16dp">
 
@@ -17,12 +17,12 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginEnd="12dp"
-            android:textSize="14sp"
             android:textColor="@color/textColorPrimary"
+            android:textSize="14sp"
             android:textStyle="bold"
-            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintEnd_toStartOf="@id/textViewPlatform"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toStartOf="@id/textViewPlatform" />
+            app:layout_constraintTop_toTopOf="parent" />
 
         <TextView
             android:id="@+id/textViewDate"
@@ -30,30 +30,30 @@
             android:layout_height="wrap_content"
             android:layout_marginTop="4dp"
             android:layout_marginEnd="12dp"
-            android:textSize="12sp"
             android:textColor="@color/textColorSecondary"
-            app:layout_constraintTop_toBottomOf="@id/textViewKey"
+            android:textSize="12sp"
+            app:layout_constraintEnd_toStartOf="@id/textViewPlatform"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toStartOf="@id/textViewPlatform" />
+            app:layout_constraintTop_toBottomOf="@id/textViewKey" />
 
         <TextView
             android:id="@+id/textViewPlatform"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:paddingVertical="4dp"
             android:paddingHorizontal="8dp"
-            android:textSize="12sp"
+            android:paddingVertical="4dp"
             android:textColor="@color/textColorPrimary"
-            app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintEnd_toEndOf="parent" />
+            android:textSize="12sp"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
 
         <HorizontalScrollView
             android:id="@+id/horizontalScrollView"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="16dp"
-            app:layout_constraintTop_toBottomOf="@id/textViewDate"
             app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/textViewDate"
             app:layout_constraintVertical_bias="0"
             tools:background="@drawable/analytics_logger_json_background">
 
@@ -62,11 +62,34 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:padding="8dp"
-                android:textSize="13sp"
-                android:textColor="@color/textColorPrimary" />
+                android:textColor="@color/textColorPrimary"
+                android:textSize="13sp" />
 
         </HorizontalScrollView>
 
+        <WebView
+            android:id="@+id/webViewJsExecutor"
+            android:layout_width="1dp"
+            android:layout_height="1dp"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/horizontalScrollView" />
+
+        <androidx.appcompat.widget.SwitchCompat
+            android:id="@+id/checkboxShowJSTransformFunction"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Edit JS Transform Function"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/webViewJsExecutor" />
+
+        <androidx.appcompat.widget.AppCompatEditText
+            android:id="@+id/editTextjsTransformFunction"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            android:visibility="gone"
+            app:layout_constraintTop_toBottomOf="@+id/checkboxShowJSTransformFunction" />
     </androidx.constraintlayout.widget.ConstraintLayout>
 
 </androidx.core.widget.NestedScrollView>

--- a/libraries/analytics-logger/src/main/res/menu/analytics_logger_menu_event_detail.xml
+++ b/libraries/analytics-logger/src/main/res/menu/analytics_logger_menu_event_detail.xml
@@ -3,6 +3,12 @@
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <item
+        android:id="@+id/action_test_assert"
+        android:title="@string/analytics_logger_action_copy"
+        android:icon="@drawable/analytics_logger_check_list"
+        app:showAsAction="always" />
+
+    <item
         android:id="@+id/action_copy"
         android:title="@string/analytics_logger_action_copy"
         android:icon="@drawable/analytics_logger_copy_all"

--- a/sample/src/main/java/com/trendyol/android/devtools/App.kt
+++ b/sample/src/main/java/com/trendyol/android/devtools/App.kt
@@ -33,6 +33,14 @@ class App : Application() {
         // Analytics Logger
         AnalyticsLogger.init(this)
 
+        // Configure JavaScript transformation function
+        AnalyticsLogger.setEventTransformFunction(
+            """
+            function transform(data) {
+                return data;
+            }""".trimIndent(),
+        )
+
         // View Inspector
         ViewInspector.init(this)
 

--- a/sample/src/main/java/com/trendyol/android/devtools/App.kt
+++ b/sample/src/main/java/com/trendyol/android/devtools/App.kt
@@ -38,7 +38,8 @@ class App : Application() {
             """
             function transform(data) {
                 return data;
-            }""".trimIndent(),
+            }
+            """.trimIndent(),
         )
 
         // View Inspector


### PR DESCRIPTION
- Start analytics logger with different task affinity.
- Add a transform and copy menu item to convert analytic events into different kind of strings such as testing assertions.

<img width="386" alt="Screenshot 2025-07-05 at 15 28 47" src="https://github.com/user-attachments/assets/64bb5a97-39e1-43f1-a434-612423defeb5" />
