### PR TITLE
Add source to events

### DIFF
--- a/libraries/analytics-logger-no-op/build.gradle.kts
+++ b/libraries/analytics-logger-no-op/build.gradle.kts
@@ -33,7 +33,7 @@ android {
 }
 
 group = "com.trendyol.android.devtools"
-version = "0.5.0"
+version = "0.6.0"
 
 publishConfig {
     defaultConfiguration(

--- a/libraries/analytics-logger/build.gradle.kts
+++ b/libraries/analytics-logger/build.gradle.kts
@@ -39,7 +39,7 @@ android {
 }
 
 group = "com.trendyol.android.devtools"
-version = "0.5.0"
+version = "0.6.0"
 
 publishConfig {
     defaultConfiguration(

--- a/libraries/analytics-logger/src/main/java/com/trendyol/android/devtools/analyticslogger/AnalyticsLogger.kt
+++ b/libraries/analytics-logger/src/main/java/com/trendyol/android/devtools/analyticslogger/AnalyticsLogger.kt
@@ -60,24 +60,26 @@ object AnalyticsLogger {
         instance?.hideNotification() ?: Log.w(TAG, INIT_ERROR_MESSAGE)
     }
 
-    fun report(key: String?, value: String?, platform: String?) {
-        instance?.reportEvent(key, value, platform) ?: Log.w(TAG, INIT_ERROR_MESSAGE)
+    fun report(key: String?, value: String?, platform: String?, source: String?) {
+        instance?.reportEvent(key, value, platform, source) ?: Log.w(TAG, INIT_ERROR_MESSAGE)
     }
 
     /**
-     * Reports an event with the specified key, value, platform, and success status.
+     * Reports an analytics event with comprehensive tracking information.
      *
      * @param key The key identifying the event. Can be null.
-     * @param value The value associated with the event. Can be null.
-     * @param platform The platform related to the event. Can be null.
+     * @param value The value associated with the event (usually JSON data). Can be null.
+     * @param platform The analytics platform (e.g., "Firebase", "Amplitude"). Can be null.
      * @param isSuccess Indicates whether the operation was successful. Can be null.
+     * @param source The source of the event (e.g., "com.trendyol.product.ProductClickEvent"). Can be null.
      */
     fun report(
         key: String?,
         value: String?,
         platform: String?,
-        isSuccess: Boolean?,
+        source: String?,
+        isSuccess: Boolean? = null,
     ) {
-        instance?.reportEvent(key, value, platform, isSuccess) ?: Log.w(TAG, INIT_ERROR_MESSAGE)
+        instance?.reportEvent(key, value, platform, source, isSuccess) ?: Log.w(TAG, INIT_ERROR_MESSAGE)
     }
 }

--- a/libraries/analytics-logger/src/main/java/com/trendyol/android/devtools/analyticslogger/internal/NotificationManager.kt
+++ b/libraries/analytics-logger/src/main/java/com/trendyol/android/devtools/analyticslogger/internal/NotificationManager.kt
@@ -59,12 +59,14 @@ internal class NotificationManager constructor(private var showNotification: Boo
         key: String?,
         value: String?,
         platform: String?,
+        source: String?,
         isSuccess: Boolean? = null,
     ) = scope.launch {
         analyticsContainer.eventManager.insert(
             key = key,
             value = value,
             platform = platform,
+            source = source,
             isSuccess = isSuccess,
         )
         lastEvent = key to platform

--- a/libraries/analytics-logger/src/main/java/com/trendyol/android/devtools/analyticslogger/internal/data/database/EventDatabase.kt
+++ b/libraries/analytics-logger/src/main/java/com/trendyol/android/devtools/analyticslogger/internal/data/database/EventDatabase.kt
@@ -9,7 +9,7 @@ import androidx.sqlite.db.SupportSQLiteDatabase
 import com.trendyol.android.devtools.analyticslogger.internal.data.dao.EventDao
 import com.trendyol.android.devtools.analyticslogger.internal.data.model.EventEntity
 
-@Database(entities = [EventEntity::class], version = 2)
+@Database(entities = [EventEntity::class], version = 3)
 internal abstract class EventDatabase : RoomDatabase() {
 
     abstract fun eventDao(): EventDao
@@ -29,6 +29,11 @@ internal abstract class EventDatabase : RoomDatabase() {
             object : Migration(1, 2) {
                 override fun migrate(db: SupportSQLiteDatabase) {
                     db.execSQL("ALTER TABLE event_entities ADD COLUMN isSuccess INTEGER")
+                }
+            },
+            object : Migration(2, 3) {
+                override fun migrate(db: SupportSQLiteDatabase) {
+                    db.execSQL("ALTER TABLE event_entities ADD COLUMN source TEXT")
                 }
             },
         )

--- a/libraries/analytics-logger/src/main/java/com/trendyol/android/devtools/analyticslogger/internal/data/model/EventEntity.kt
+++ b/libraries/analytics-logger/src/main/java/com/trendyol/android/devtools/analyticslogger/internal/data/model/EventEntity.kt
@@ -11,5 +11,6 @@ internal data class EventEntity(
     @ColumnInfo(name = "value") val value: String?,
     @ColumnInfo(name = "platform") val platform: String?,
     @ColumnInfo(name = "date") val date: String?,
+    @ColumnInfo(name = "source") val source: String?,
     @ColumnInfo(name = "isSuccess") val isSuccess: Boolean?,
 )

--- a/libraries/analytics-logger/src/main/java/com/trendyol/android/devtools/analyticslogger/internal/domain/manager/EventManager.kt
+++ b/libraries/analytics-logger/src/main/java/com/trendyol/android/devtools/analyticslogger/internal/domain/manager/EventManager.kt
@@ -6,7 +6,13 @@ internal interface EventManager {
 
     suspend fun find(query: String?, platform: String, page: Int, pageSize: Int): List<Event>
 
-    suspend fun insert(key: String?, value: String?, platform: String?, isSuccess: Boolean? = null)
+    suspend fun insert(
+        key: String?,
+        value: String?,
+        platform: String?,
+        source: String?,
+        isSuccess: Boolean? = null,
+    )
 
     suspend fun deleteAll()
 

--- a/libraries/analytics-logger/src/main/java/com/trendyol/android/devtools/analyticslogger/internal/domain/manager/EventManagerImpl.kt
+++ b/libraries/analytics-logger/src/main/java/com/trendyol/android/devtools/analyticslogger/internal/domain/manager/EventManagerImpl.kt
@@ -28,6 +28,7 @@ internal class EventManagerImpl(
         key: String?,
         value: String?,
         platform: String?,
+        source: String?,
         isSuccess: Boolean?,
     ) {
         val dateFormat = SimpleDateFormat("HH:mm:ss", Locale.getDefault())
@@ -39,6 +40,7 @@ internal class EventManagerImpl(
                 value = value,
                 platform = platform,
                 date = date,
+                source = source,
                 isSuccess = isSuccess,
             )
         )
@@ -73,6 +75,7 @@ internal class EventManagerImpl(
                 platform = eventEntity.platform,
                 date = eventEntity.date,
                 isSuccess = eventEntity.isSuccess,
+                source = eventEntity.source,
             )
         }
 

--- a/libraries/analytics-logger/src/main/java/com/trendyol/android/devtools/analyticslogger/internal/domain/model/Event.kt
+++ b/libraries/analytics-logger/src/main/java/com/trendyol/android/devtools/analyticslogger/internal/domain/model/Event.kt
@@ -7,5 +7,6 @@ internal data class Event(
     val json: String?,
     val platform: String?,
     val date: String?,
+    val source: String?,
     val isSuccess: Boolean?,
 )

--- a/libraries/analytics-logger/src/main/java/com/trendyol/android/devtools/analyticslogger/internal/ui/EventAdapter.kt
+++ b/libraries/analytics-logger/src/main/java/com/trendyol/android/devtools/analyticslogger/internal/ui/EventAdapter.kt
@@ -59,7 +59,7 @@ internal class EventAdapter : PagingDataAdapter<Event, EventAdapter.EventViewHol
             boundItem = event
 
             textViewKey.text = event.key
-            textViewValue.text = event.value
+            textViewSource.text = event.source
             textViewPlatform.text = event.platform
             textViewDate.text = event.date
             textViewPlatform.background = createPlatformBackground(event.platform)

--- a/libraries/analytics-logger/src/main/java/com/trendyol/android/devtools/analyticslogger/internal/ui/detail/DetailFragment.kt
+++ b/libraries/analytics-logger/src/main/java/com/trendyol/android/devtools/analyticslogger/internal/ui/detail/DetailFragment.kt
@@ -75,6 +75,7 @@ internal class DetailFragment : Fragment() {
     private fun renderState(state: DetailState) = with(binding) {
         if (state is DetailState.Selected) {
             textViewKey.text = state.event.key
+            textViewSource.text = state.event.source
             textViewValue.text = state.event.json
             textViewDate.text = state.event.date
             textViewPlatform.text = state.event.platform

--- a/libraries/analytics-logger/src/main/java/com/trendyol/android/devtools/analyticslogger/internal/ui/detail/DetailFragment.kt
+++ b/libraries/analytics-logger/src/main/java/com/trendyol/android/devtools/analyticslogger/internal/ui/detail/DetailFragment.kt
@@ -136,10 +136,18 @@ internal class DetailFragment : Fragment() {
         return binding.webViewJsExecutor.executeJS(jsScript.toString())
     }
 
+    private fun copySourceToClipboard() {
+        val source = (viewModel.detailState.value as? DetailState.Selected)?.event?.source.orEmpty()
+        val clipboard = context?.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+        clipboard.setPrimaryClip(ClipData.newPlainText(CLIPBOARD_SOURCE_LABEL, source))
+        Toast.makeText(context, R.string.analytics_logger_toast_copied, Toast.LENGTH_SHORT).show()
+    }
+
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         when (item.itemId) {
             R.id.action_copy -> copyToClipboard()
             R.id.action_test_assert -> copyTransformedToClipboard()
+            R.id.action_copy_source -> copySourceToClipboard()
         }
         return super.onOptionsItemSelected(item)
     }
@@ -158,6 +166,7 @@ internal class DetailFragment : Fragment() {
         const val NAME = "detailFragment"
         private const val CLIPBOARD_LABEL = "Event Detail"
         private const val CLIPBOARD_TRANSFORMED_LABEL = "Transformed Event Detail"
+        private const val CLIPBOARD_SOURCE_LABEL = "Event Source"
 
         fun newInstance(): DetailFragment {
             return DetailFragment()

--- a/libraries/analytics-logger/src/main/res/drawable/ic_class.xml
+++ b/libraries/analytics-logger/src/main/res/drawable/ic_class.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="16dp"
+    android:height="16dp"
+    android:viewportWidth="16"
+    android:viewportHeight="16">
+
+    <path
+        android:fillColor="#000000"
+        android:fillType="evenOdd"
+        android:pathData="M1.25,2C1.25,1.586 1.586,1.25 2,1.25H14C14.303,1.25 14.577,1.433 14.693,1.713C14.809,1.993 14.745,2.316 14.53,2.53L9.061,8L14.53,13.47C14.745,13.684 14.809,14.007 14.693,14.287C14.577,14.567 14.303,14.75 14,14.75H2C1.586,14.75 1.25,14.414 1.25,14V2ZM2.75,2.75V13.25H12.189L7.47,8.53C7.177,8.237 7.177,7.763 7.47,7.47L12.189,2.75H2.75Z" />
+
+</vector>

--- a/libraries/analytics-logger/src/main/res/layout/analytics_logger_fragment_detail.xml
+++ b/libraries/analytics-logger/src/main/res/layout/analytics_logger_fragment_detail.xml
@@ -34,8 +34,24 @@
             android:textSize="12sp"
             app:layout_constraintEnd_toStartOf="@id/textViewPlatform"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/textViewKey" />
+            app:layout_constraintTop_toBottomOf="@id/textViewKey"
+            tools:text="12.00PM"/>
 
+        <TextView
+            android:id="@+id/textViewSource"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="2dp"
+            android:layout_marginEnd="12dp"
+            android:textColor="@color/textColorPrimary"
+            android:ellipsize="end"
+            android:lines="2"
+            android:textSize="12sp"
+            android:textStyle="italic"
+            app:layout_constraintEnd_toStartOf="@id/textViewPlatform"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/textViewDate"
+            tools:text="com.trendyol.product.ProductClickEvent" />
         <TextView
             android:id="@+id/textViewPlatform"
             android:layout_width="wrap_content"
@@ -53,7 +69,7 @@
             android:layout_height="wrap_content"
             android:layout_marginTop="16dp"
             app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/textViewDate"
+            app:layout_constraintTop_toBottomOf="@id/textViewSource"
             app:layout_constraintVertical_bias="0"
             tools:background="@drawable/analytics_logger_json_background">
 

--- a/libraries/analytics-logger/src/main/res/layout/analytics_logger_item_event.xml
+++ b/libraries/analytics-logger/src/main/res/layout/analytics_logger_item_event.xml
@@ -25,7 +25,7 @@
         tools:text="event-screen-seen" />
 
     <TextView
-        android:id="@+id/textViewValue"
+        android:id="@+id/textViewSource"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginTop="2dp"
@@ -38,7 +38,7 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toStartOf="@id/textViewPlatform"
-        tools:text="Lorem ipsum dolor" />
+        tools:text="com.example.package.ClassName" />
 
     <TextView
         android:id="@+id/textViewPlatform"

--- a/libraries/analytics-logger/src/main/res/menu/analytics_logger_menu_event_detail.xml
+++ b/libraries/analytics-logger/src/main/res/menu/analytics_logger_menu_event_detail.xml
@@ -3,6 +3,12 @@
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <item
+        android:id="@+id/action_copy_source"
+        android:title="@string/analytics_logger_action_copy_source"
+        android:icon="@drawable/ic_class"
+        app:showAsAction="always" />
+
+    <item
         android:id="@+id/action_test_assert"
         android:title="@string/analytics_logger_action_copy"
         android:icon="@drawable/analytics_logger_check_list"

--- a/libraries/analytics-logger/src/main/res/values/strings.xml
+++ b/libraries/analytics-logger/src/main/res/values/strings.xml
@@ -8,6 +8,7 @@
     <string name="analytics_logger_title">Analytics Events</string>
 
     <string name="analytics_logger_action_copy">Copy</string>
+    <string name="analytics_logger_action_copy_source">Source</string>
 
     <string name="analytics_logger_toast_copied">Copied to the clipboard.</string>
 </resources>

--- a/sample/src/main/java/com/trendyol/android/devtools/ui/main/MainFragment.kt
+++ b/sample/src/main/java/com/trendyol/android/devtools/ui/main/MainFragment.kt
@@ -75,11 +75,13 @@ class MainFragment : Fragment() {
             key = "OnMainFragmentSeenEvent",
             value = "{\"category\": \"Cart\", \"data\": \"TestData\" }",
             platform = "Firebase",
+            source = "com.trendyol.MainFragmentSeenEvent",
             isSuccess = true,
         )
         AnalyticsLogger.report(
             key = "OnMainFragmentSeenFailEvent",
             value = "{\"category\": \"Cart\", \"data\": \"TestData\" }",
+            source = "com.trendyol.MainFragmentSeenFailEvent",
             platform = "Firebase",
         )
     }


### PR DESCRIPTION
show event package and class name as source in listing and detail pages. Also copy the package + class path as string with toolbar copy button.

<img width="383" height="419" alt="Screenshot 2025-08-18 at 17 25 23" src="https://github.com/user-attachments/assets/a7a847d2-0703-4a89-b2e0-e681e5886ea9" />
<img width="383" height="419" alt="Screenshot 2025-08-18 at 17 25 02" src="https://github.com/user-attachments/assets/f1319769-5e34-423f-af9a-1b3cb8000c76" />
